### PR TITLE
fix: remove @use-it/event-listener dependency

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -9,13 +9,6 @@
 
   <body>
     <div id="root"></div>
-    <script>
-      // hack for Vite
-      if (typeof global === 'undefined') {
-        if (typeof globalThis !== 'undefined') global = globalThis;
-        else global = window;
-      }
-    </script>
     <script type="module" src="./index.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     }
   },
   "dependencies": {
-    "@use-it/event-listener": "0.1.6",
     "@xstate/react": "1.3.1",
     "xstate": "4.16.2"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import useEventListener from '@use-it/event-listener';
+import * as React from 'react';
 import { createMachine, assign } from 'xstate';
 import { useMachine } from '@xstate/react';
 import { isEqual, takeRight } from './utils';
@@ -126,7 +126,14 @@ function createCheatCodeMachine(cheatCodeKeys: Array<string>) {
 
 export function useCheatCode(cheatCodeKeys: Array<string>): boolean {
   const [current, send] = useMachine(createCheatCodeMachine(cheatCodeKeys));
-  useEventListener<'keydown'>('keydown', send);
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', send);
+    return () => {
+      window.removeEventListener('keydown', send);
+    };
+  }, [send]);
+
   return current.matches('enabled');
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,11 +2210,6 @@
     "@typescript-eslint/types" "4.16.1"
     eslint-visitor-keys "^2.0.0"
 
-"@use-it/event-listener@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.6.tgz#5776274fec72f3f25af9ead1898e7f45bc435812"
-  integrity sha512-e6V7vbU8xpuqy4GZkTLExHffOFgxmGHo3kNWnlhzM/zcX2v+idbD/HaJ9sKdQMgTh+L7MIhdRDXGX3SdAViZzA==
-
 "@wkovacs64/prettier-config@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@wkovacs64/prettier-config/-/prettier-config-3.0.0.tgz#e56992085ea1896a88adf36f8a279ffd6b0fc467"


### PR DESCRIPTION
`@use-it/event-listener` uses `global` which isn't working with Gatsby v3 (seemingly due to webpack v5 usage) nor a few other build tools. Not sure what the correct fix is there, but we don't need to depend on this library anyway for our simple use-case so removing it is easiest for now.