### PR TITLE
Add support for `onCheatCodeEntered` callback in `useCheatCode` hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ const cheatCodeMachine = setup({
   },
 });
 
-export function useCheatCode(cheatCodeKeys: string[]): boolean {
+export function useCheatCode(cheatCodeKeys: string[], onCheatCodeEntered?: () => void): boolean {
   const machineOpts = React.useMemo<{ input: CheatCodeMachineInput }>(
     () => ({ input: { cheatCodeKeys } }),
     [cheatCodeKeys],
@@ -142,6 +142,10 @@ export function useCheatCode(cheatCodeKeys: string[]): boolean {
   const [state, send] = useMachine(cheatCodeMachine, machineOpts);
 
   React.useEffect(() => {
+    if (state.matches('enabled') && onCheatCodeEntered) {
+      onCheatCodeEntered(); // Trigger the custom callback when cheat code is entered
+    }
+
     const handleKeydownEvent = (event: KeyboardEvent) => {
       send(event as KeydownEvent);
     };


### PR DESCRIPTION
### Description:

This PR introduces a new optional parameter `onCheatCodeEntered` to the `useCheatCode` hook. This parameter allows users to pass a custom callback function that will be triggered whenever the cheat code is successfully entered.

This feature is useful for triggering custom side effects (e.g., UI updates, state changes, alerts) once the cheat code is detected.

### Changes:

`useCheatCode` Hook:

Added the onCheatCodeEntered callback to the hook.

The callback is triggered when the cheat code is successfully entered (i.e., when the state of the machine matches the enabled state).

Example Usage:
```ts
const onCheatCodeEntered = () => {
  alert('Cheat code activated!');
};

const isCheatCodeActive = useCheatCode(['UP', 'UP', 'DOWN', 'DOWN'], onCheatCodeEntered);
```