### PR TITLE
chore: reduce pnpm minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,4 @@ allowBuilds:
   esbuild: false
   unrs-resolver: false
 
-minimumReleaseAge: 4320
+minimumReleaseAge: 1440


### PR DESCRIPTION
Set pnpm minimumReleaseAge to 1440 minutes.